### PR TITLE
Milestone 2 - In-memory cache

### DIFF
--- a/api-clusters/pom.xml
+++ b/api-clusters/pom.xml
@@ -101,6 +101,11 @@
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
 		<!-- General -->
 		<dependency>
 		    <groupId>de.codecentric</groupId>
@@ -139,6 +144,22 @@
 			<groupId>ma.glasnost.orika</groupId>
 			<artifactId>orika-core</artifactId>
 			<version>${orika-core.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.0.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- TWA -->

--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/configuration/CacheManagerConfiguration.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/configuration/CacheManagerConfiguration.java
@@ -1,0 +1,27 @@
+package com.twa.flights.api.clusters.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.twa.flights.api.clusters.configuration.settings.CacheConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@EnableCaching
+@Configuration
+public class CacheManagerConfiguration {
+    @Bean
+    public Caffeine caffeineConfig(CacheConfiguration configuration) {
+        return Caffeine.newBuilder().expireAfterWrite(configuration.getDuration(), TimeUnit.MINUTES)
+                .maximumSize(configuration.getMaxSize());
+    }
+
+    @Bean
+    public CaffeineCacheManager cacheManager(Caffeine caffeineConfig) {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("catalog");
+        cacheManager.setCaffeine(caffeineConfig);
+        return cacheManager;
+    }
+}

--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/configuration/settings/CacheConfiguration.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/configuration/settings/CacheConfiguration.java
@@ -1,0 +1,17 @@
+package com.twa.flights.api.clusters.configuration.settings;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "cache")
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+    private int maxSize;
+    private int duration;
+}

--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/service/CatalogService.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/service/CatalogService.java
@@ -3,12 +3,14 @@ package com.twa.flights.api.clusters.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.*;
 import org.springframework.stereotype.Service;
 
 import com.twa.flights.api.clusters.connector.CatalogConnector;
 import com.twa.flights.api.clusters.dto.CityDTO;
 
 @Service
+@CacheConfig(cacheNames = { "catalog" })
 public class CatalogService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogService.class);
@@ -20,6 +22,7 @@ public class CatalogService {
         this.catalogConnector = catalogConnector;
     }
 
+    @Cacheable(unless="#result == null")
     public CityDTO getCity(String code) {
         LOGGER.debug("Obtain the information for code: {}", code);
         return catalogConnector.getCityByCode(code);

--- a/api-clusters/src/main/resources/application-docker.yml
+++ b/api-clusters/src/main/resources/application-docker.yml
@@ -35,6 +35,10 @@ redis:
    host: api-clusters-db
    port: 6379    
 
+cache:
+  max-size: 100
+  duration: 60
+
 connector:
    catalog:
       host: api-catalog:6070

--- a/api-clusters/src/main/resources/application.yml
+++ b/api-clusters/src/main/resources/application.yml
@@ -34,6 +34,10 @@ spring:
 redis:
    host: localhost
    port: 6079
+
+cache:
+    max-size: 100
+    duration: 60
     
 connector:
    catalog:

--- a/api-provider-alpha/pom.xml
+++ b/api-provider-alpha/pom.xml
@@ -98,6 +98,11 @@
 			<artifactId>spring-tx</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
 		<!-- General -->
 		<dependency>
 		    <groupId>de.codecentric</groupId>
@@ -149,6 +154,22 @@
 			<groupId>ma.glasnost.orika</groupId>
 			<artifactId>orika-core</artifactId>
 			<version>${orika-core.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.0.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- TWA -->

--- a/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/configuration/CacheConfiguration.java
+++ b/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/configuration/CacheConfiguration.java
@@ -1,0 +1,14 @@
+package com.twa.flights.api.provider.alpha.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.*;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "cache")
+@Configuration
+public class CacheConfiguration {
+    private int maxSize;
+    private int duration;
+}

--- a/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/configuration/CacheManagerConfiguration.java
+++ b/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/configuration/CacheManagerConfiguration.java
@@ -1,0 +1,25 @@
+package com.twa.flights.api.provider.alpha.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.*;
+
+import java.util.concurrent.TimeUnit;
+
+@EnableCaching
+@Configuration
+public class CacheManagerConfiguration {
+    @Bean
+    public Caffeine caffeineConfig(CacheConfiguration configuration) {
+        return Caffeine.newBuilder().expireAfterWrite(configuration.getDuration(), TimeUnit.MINUTES)
+                .maximumSize(configuration.getMaxSize());
+    }
+
+    @Bean
+    public CaffeineCacheManager cacheManager(Caffeine caffeineConfig) {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("catalog");
+        cacheManager.setCaffeine(caffeineConfig);
+        return cacheManager;
+    }
+}

--- a/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/service/CatalogService.java
+++ b/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/service/CatalogService.java
@@ -22,7 +22,7 @@ public class CatalogService {
         this.catalogConnector = catalogConnector;
     }
 
-    @Cacheable
+    @Cacheable(unless="#result == null")
     public CityDTO getCity(String code) {
         LOGGER.debug("Obtain the information for code: {}", code);
         return catalogConnector.getCityByCode(code);

--- a/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/service/CatalogService.java
+++ b/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/service/CatalogService.java
@@ -3,12 +3,14 @@ package com.twa.flights.api.provider.alpha.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.*;
 import org.springframework.stereotype.Service;
 
 import com.twa.flights.api.provider.alpha.connector.CatalogConnector;
 import com.twa.flights.api.provider.alpha.dto.CityDTO;
 
 @Service
+@CacheConfig(cacheNames = { "catalog" })
 public class CatalogService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogService.class);
@@ -20,6 +22,7 @@ public class CatalogService {
         this.catalogConnector = catalogConnector;
     }
 
+    @Cacheable
     public CityDTO getCity(String code) {
         LOGGER.debug("Obtain the information for code: {}", code);
         return catalogConnector.getCityByCode(code);

--- a/api-provider-alpha/src/main/resources/application-docker.yml
+++ b/api-provider-alpha/src/main/resources/application-docker.yml
@@ -15,7 +15,11 @@ jetty:
   threadPool:
     maxThreads: 10
     minThreads: 10
-    
+
+cache:
+  max-size: 100
+  duration: 60
+
 chaos:
   monkey:
     enabled: false

--- a/api-provider-alpha/src/main/resources/application.yml
+++ b/api-provider-alpha/src/main/resources/application.yml
@@ -15,7 +15,11 @@ jetty:
   threadPool:
     maxThreads: 10
     minThreads: 10
-    
+
+cache:
+  max-size: 100
+  duration: 60
+
 chaos:
   monkey:
     enabled: false

--- a/api-provider-beta/pom.xml
+++ b/api-provider-beta/pom.xml
@@ -98,6 +98,11 @@
 			<artifactId>spring-tx</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
 		<!-- General -->
 		<dependency>
 		    <groupId>de.codecentric</groupId>
@@ -149,6 +154,22 @@
 			<groupId>ma.glasnost.orika</groupId>
 			<artifactId>orika-core</artifactId>
 			<version>${orika-core.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.0.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- TWA -->

--- a/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/configuration/CacheConfiguration.java
+++ b/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/configuration/CacheConfiguration.java
@@ -1,0 +1,14 @@
+package com.twa.flights.api.provider.beta.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.*;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "cache")
+@Configuration
+public class CacheConfiguration {
+    private int maxSize;
+    private int duration;
+}

--- a/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/configuration/CacheManagerConfiguration.java
+++ b/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/configuration/CacheManagerConfiguration.java
@@ -1,0 +1,25 @@
+package com.twa.flights.api.provider.beta.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.*;
+
+import java.util.concurrent.TimeUnit;
+
+@EnableCaching
+@Configuration
+public class CacheManagerConfiguration {
+    @Bean
+    public Caffeine caffeineConfig(CacheConfiguration configuration) {
+        return Caffeine.newBuilder().expireAfterWrite(configuration.getDuration(), TimeUnit.MINUTES)
+                .maximumSize(configuration.getMaxSize());
+    }
+
+    @Bean
+    public CaffeineCacheManager cacheManager(Caffeine caffeineConfig) {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("catalog");
+        cacheManager.setCaffeine(caffeineConfig);
+        return cacheManager;
+    }
+}

--- a/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/service/CatalogService.java
+++ b/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/service/CatalogService.java
@@ -22,7 +22,7 @@ public class CatalogService {
         this.catalogConnector = catalogConnector;
     }
 
-    @Cacheable
+    @Cacheable(unless="#result == null")
     public CityDTO getCity(String code) {
         LOGGER.debug("Obtain the information for code: {}", code);
         return catalogConnector.getCityByCode(code);

--- a/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/service/CatalogService.java
+++ b/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/service/CatalogService.java
@@ -3,12 +3,14 @@ package com.twa.flights.api.provider.beta.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.*;
 import org.springframework.stereotype.Service;
 
 import com.twa.flights.api.provider.beta.connector.CatalogConnector;
 import com.twa.flights.api.provider.beta.dto.CityDTO;
 
 @Service
+@CacheConfig(cacheNames = { "catalog" })
 public class CatalogService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogService.class);
@@ -20,6 +22,7 @@ public class CatalogService {
         this.catalogConnector = catalogConnector;
     }
 
+    @Cacheable
     public CityDTO getCity(String code) {
         LOGGER.debug("Obtain the information for code: {}", code);
         return catalogConnector.getCityByCode(code);

--- a/api-provider-beta/src/main/resources/application-docker.yml
+++ b/api-provider-beta/src/main/resources/application-docker.yml
@@ -15,7 +15,11 @@ jetty:
   threadPool:
     maxThreads: 10
     minThreads: 10
-    
+
+cache:
+  max-size: 100
+  duration: 60
+
 chaos:
   monkey:
     enabled: false

--- a/api-provider-beta/src/main/resources/application.yml
+++ b/api-provider-beta/src/main/resources/application.yml
@@ -16,6 +16,10 @@ jetty:
     maxThreads: 10
     minThreads: 10
 
+cache:
+  max-size: 100
+  duration: 60
+
 chaos:
   monkey:
     enabled: false


### PR DESCRIPTION
# Reduce Traffic - Milestone 2

Add in-memory cache, using Caffeine, for services `api-clusters`, `api-provider-alpha` and `api-provider-beta`. 

**NOTE:** For such a simple example, have no idea on sensible configuration for cache.

*(I know, I know, ... I should have extracted the DTOs to the missing maven artifact `com.twa.flights.common:flights-common-dto`)*