### PR TITLE
Milestone 3 - External cache in front of service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ target/
 .settings/
 .project
 .classpath
+
+# IntelliJ
+*.iml
+.idea/

--- a/api-clusters/.gitignore
+++ b/api-clusters/.gitignore
@@ -27,3 +27,8 @@ target/
 .settings/
 .project
 .classpath
+
+
+# IntelliJ
+*.iml
+.idea

--- a/api-clusters/.gitignore
+++ b/api-clusters/.gitignore
@@ -27,8 +27,3 @@ target/
 .settings/
 .project
 .classpath
-
-
-# IntelliJ
-*.iml
-.idea

--- a/api-clusters/src/main/resources/application-docker.yml
+++ b/api-clusters/src/main/resources/application-docker.yml
@@ -37,7 +37,7 @@ redis:
 
 connector:
    catalog:
-      host: api-catalog:6070
+      host: api-catalog-varnish:80
       responseTimeout: 2000
       connectionTimeout: 2000
       readTimeout: 2000

--- a/api-provider-alpha/src/main/resources/application-docker.yml
+++ b/api-provider-alpha/src/main/resources/application-docker.yml
@@ -33,7 +33,7 @@ spring:
     
 connector:
    catalog:
-      host: api-catalog:6070
+      host: api-catalog-varnish:80
       responseTimeout: 1000
       connectionTimeout: 1000
       readTimeout: 1000

--- a/api-provider-beta/src/main/resources/application-docker.yml
+++ b/api-provider-beta/src/main/resources/application-docker.yml
@@ -33,7 +33,7 @@ spring:
         
 connector:
    catalog:
-      host: api-catalog:6070
+      host: api-catalog-varnish:80
       responseTimeout: 1000
       connectionTimeout: 1000
       readTimeout: 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,17 @@ services:
       MYSQL_USER: 'root'
       MYSQL_PASSWORD: 'muppet'
       MYSQL_ROOT_PASSWORD: 'muppet'
-      
+
+
+  api-catalog-varnish:
+    build: varnish/.
+    container_name: api-catalog-varnish
+    ports:
+      - 6080:80
+    restart: always
+    depends_on:
+      - api-catalog
+
   api-clusters:
     build: api-clusters/.
     container_name: api-clusters
@@ -38,7 +48,7 @@ services:
     container_name: api-itineraries-search
     ports:
      - 7070:7070
-    restart: always   
+    restart: always
 
   api-pricing:
     build: api-pricing/.
@@ -69,4 +79,4 @@ services:
     container_name: api-provider-beta
     ports:
      - 9070:9070
-    restart: always      
+    restart: always

--- a/varnish/Dockerfile
+++ b/varnish/Dockerfile
@@ -1,0 +1,7 @@
+FROM varnish:6.5
+
+COPY default.vcl /etc/varnish/
+
+ENV VARNISH_MEMORY 100m
+
+EXPOSE 80

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -1,0 +1,41 @@
+vcl 4.0;
+
+import std;
+
+backend default {
+  .host = "api-catalog";
+  .port = "6070";
+}
+
+sub vcl_recv {
+    if (req.url ~ "^/api/" && req.method == "GET") {
+
+        # Normalize the query parameters
+        set req.url = std.querysort(req.url);
+
+        # Strip the cookies
+        unset req.http.cookie;
+
+        return(hash);
+    } else {
+        return(pass);
+    }
+}
+
+sub vcl_backend_response {
+    if (bereq.url ~ "^/api/"){
+        # time-to-live 1 hour
+        set beresp.ttl = 3600s;
+        unset beresp.http.set-cookie;
+        unset beresp.http.Pragma;
+        unset beresp.http.Expires;
+    }
+
+    # dont cache redirects and errors
+    if (beresp.status >= 300) {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 30s;
+        return (deliver);
+    }
+    return (deliver);
+}


### PR DESCRIPTION
# Reduce traffic - Milestone 3.

Add external cache, using Varnish, in front of `api-catalog`, redirecting `api-clusters`, `api-provider-alpha` and `api-provider-beta` to it.

All GET request for `/api/**` are being cached. TTL is set to 1 hour.