### PR TITLE
Compress communication - Milestone 3

### DIFF
--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/serializer/JsonSerializer.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/serializer/JsonSerializer.java
@@ -29,7 +29,8 @@ public class JsonSerializer {
     public static byte[] serialize(Object object) {
         byte[] compressedJson = null;
         try {
-            compressedJson = OBJECT_MAPPER.writeValueAsString(object).getBytes();
+            String json = OBJECT_MAPPER.writeValueAsString(object);
+            compressedJson = StringSerializer.gzip(json);
         } catch (IOException e) {
             LOGGER.error("Error serializing object: {}", e.getMessage());
         }
@@ -42,7 +43,8 @@ public class JsonSerializer {
 
         T object = null;
         try {
-            object = OBJECT_MAPPER.readValue(raw, reference);
+            String json = StringSerializer.ungzip(raw);
+            object = OBJECT_MAPPER.readValue(json, reference);
         } catch (IOException e) {
             LOGGER.error("Can't deserialize object: {}", e.getMessage());
         }

--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/serializer/StringSerializer.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/serializer/StringSerializer.java
@@ -1,0 +1,47 @@
+package com.twa.flights.api.clusters.serializer;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.*;
+
+public class StringSerializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringSerializer.class);
+
+    private StringSerializer() {
+        // just to avoid create instances
+    }
+
+    public static String ungzip(byte[] bytes) {
+        try {
+            InputStreamReader isr = new InputStreamReader(new GZIPInputStream(new ByteArrayInputStream(bytes)),
+                    StandardCharsets.UTF_8);
+            StringWriter sw = new StringWriter();
+            char[] chars = new char[1024];
+            for (int len; (len = isr.read(chars)) > 0;) {
+                sw.write(chars, 0, len);
+            }
+            return sw.toString();
+        } catch (IOException e) {
+            LOGGER.error("Error uncompressing object: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static byte[] gzip(String toCompress) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            GZIPOutputStream gzip = new GZIPOutputStream(bos);
+            OutputStreamWriter osw = new OutputStreamWriter(gzip, StandardCharsets.UTF_8);
+            osw.write(toCompress);
+            osw.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            LOGGER.error("Error compressing object: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/api-clusters/src/test/java/com/twa/flights/api/clusters/serializer/StringSerializerTest.java
+++ b/api-clusters/src/test/java/com/twa/flights/api/clusters/serializer/StringSerializerTest.java
@@ -1,0 +1,17 @@
+package com.twa.flights.api.clusters.serializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringSerializerTest {
+
+    @Test
+    public void testCompressionDecompression() {
+        String toCompress = "string to compress";
+        byte[] compressed = StringSerializer.gzip(toCompress);
+        String uncompressed = StringSerializer.ungzip(compressed);
+
+        assertEquals(uncompressed, toCompress);
+    }
+}

--- a/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/serializer/JsonSerializer.java
+++ b/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/serializer/JsonSerializer.java
@@ -24,7 +24,8 @@ public class JsonSerializer {
     public static byte[] serialize(Object object) {
         byte[] compressedJson = null;
         try {
-            compressedJson = OBJECT_MAPPER.writeValueAsString(object).getBytes();
+            String json = OBJECT_MAPPER.writeValueAsString(object);
+            compressedJson = StringSerializer.gzip(json);
         } catch (IOException e) {
             LOGGER.error("Error serializing object: {}", e.getMessage());
         }
@@ -37,7 +38,8 @@ public class JsonSerializer {
 
         T object = null;
         try {
-            object = OBJECT_MAPPER.readValue(raw, reference);
+            String json = StringSerializer.ungzip(raw);
+            object = OBJECT_MAPPER.readValue(json, reference);
         } catch (IOException e) {
             LOGGER.error("Can't deserialize object: {}", e.getMessage());
         }

--- a/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/serializer/StringSerializer.java
+++ b/api-provider-alpha/src/main/java/com/twa/flights/api/provider/alpha/serializer/StringSerializer.java
@@ -1,0 +1,45 @@
+package com.twa.flights.api.provider.alpha.serializer;
+
+import org.slf4j.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.*;
+
+public class StringSerializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringSerializer.class);
+
+    private StringSerializer() {
+        // just to avoid create instances
+    }
+
+    public static String ungzip(byte[] bytes) {
+        try {
+            InputStreamReader isr = new InputStreamReader(new GZIPInputStream(new ByteArrayInputStream(bytes)),
+                    StandardCharsets.UTF_8);
+            StringWriter sw = new StringWriter();
+            char[] chars = new char[1024];
+            for (int len; (len = isr.read(chars)) > 0;) {
+                sw.write(chars, 0, len);
+            }
+            return sw.toString();
+        } catch (IOException e) {
+            LOGGER.error("Error uncompressing object: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static byte[] gzip(String toCompress) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            GZIPOutputStream gzip = new GZIPOutputStream(bos);
+            OutputStreamWriter osw = new OutputStreamWriter(gzip, StandardCharsets.UTF_8);
+            osw.write(toCompress);
+            osw.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            LOGGER.error("Error compressing object: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/serializer/JsonSerializer.java
+++ b/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/serializer/JsonSerializer.java
@@ -24,7 +24,8 @@ public class JsonSerializer {
     public static byte[] serialize(Object object) {
         byte[] compressedJson = null;
         try {
-            compressedJson = OBJECT_MAPPER.writeValueAsString(object).getBytes();
+            String json = OBJECT_MAPPER.writeValueAsString(object);
+            compressedJson = StringSerializer.gzip(json);
         } catch (IOException e) {
             LOGGER.error("Error serializing object: {}", e.getMessage());
         }
@@ -37,7 +38,8 @@ public class JsonSerializer {
 
         T object = null;
         try {
-            object = OBJECT_MAPPER.readValue(raw, reference);
+            String json = StringSerializer.ungzip(raw);
+            object = OBJECT_MAPPER.readValue(json, reference);
         } catch (IOException e) {
             LOGGER.error("Can't deserialize object: {}", e.getMessage());
         }

--- a/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/serializer/StringSerializer.java
+++ b/api-provider-beta/src/main/java/com/twa/flights/api/provider/beta/serializer/StringSerializer.java
@@ -1,0 +1,45 @@
+package com.twa.flights.api.provider.beta.serializer;
+
+import org.slf4j.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.*;
+
+public class StringSerializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringSerializer.class);
+
+    private StringSerializer() {
+        // just to avoid create instances
+    }
+
+    public static String ungzip(byte[] bytes) {
+        try {
+            InputStreamReader isr = new InputStreamReader(new GZIPInputStream(new ByteArrayInputStream(bytes)),
+                    StandardCharsets.UTF_8);
+            StringWriter sw = new StringWriter();
+            char[] chars = new char[1024];
+            for (int len; (len = isr.read(chars)) > 0;) {
+                sw.write(chars, 0, len);
+            }
+            return sw.toString();
+        } catch (IOException e) {
+            LOGGER.error("Error uncompressing object: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static byte[] gzip(String toCompress) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            GZIPOutputStream gzip = new GZIPOutputStream(bos);
+            OutputStreamWriter osw = new OutputStreamWriter(gzip, StandardCharsets.UTF_8);
+            osw.write(toCompress);
+            osw.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            LOGGER.error("Error compressing object: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
     container_name: api-clusters-remote-cache
     image: redis:alpine
     restart: always
+    ports:
+      - 5079:6379
 
   api-itineraries-search:
     build: api-itineraries-search/.


### PR DESCRIPTION
#  Milestone 3 - Adding Compression a to Key-Value Data-Store

Add Compression to the Json string, before adding it to Redis cache, in `api-clusters`, `api-provider.alpha` and `api-provider-beta`.

Used `redis-cli` to confirm values where being compressed.