### PR TITLE
Compress communication - Milestone 4

### DIFF
--- a/api-catalog/src/main/resources/application-docker.yml
+++ b/api-catalog/src/main/resources/application-docker.yml
@@ -30,7 +30,9 @@ chaos:
 spring:
   profiles:
     active: default
-  
+  jackson:
+    default-property-inclusion: non_null
+
   flyway:
     locations: classpath:db/migration
     sql-migration-prefix: V

--- a/api-catalog/src/main/resources/application.yml
+++ b/api-catalog/src/main/resources/application.yml
@@ -30,7 +30,9 @@ chaos:
 spring:
   profiles:
     active: default
-       
+  jackson:
+    default-property-inclusion: non_null
+
   flyway:
     locations: classpath:db/migration
     sql-migration-prefix: V

--- a/api-clusters/src/main/resources/application-docker.yml
+++ b/api-clusters/src/main/resources/application-docker.yml
@@ -30,6 +30,8 @@ chaos:
 spring:
   profiles:
     active: default
+  jackson:
+    default-property-inclusion: non_null
 
 redis:
   host: api-clusters-remote-cache

--- a/api-clusters/src/main/resources/application.yml
+++ b/api-clusters/src/main/resources/application.yml
@@ -30,6 +30,8 @@ chaos:
 spring:
   profiles:
     active: default
+  jackson:
+    default-property-inclusion: non_null
 
 redis:
   host: localhost

--- a/api-itineraries-search/src/main/resources/application-docker.yml
+++ b/api-itineraries-search/src/main/resources/application-docker.yml
@@ -30,6 +30,8 @@ chaos:
 spring:
   profiles:
     active: default
+  jackson:
+    default-property-inclusion: non_null
 
 connector:  
    provider-alpha:

--- a/api-itineraries-search/src/main/resources/application.yml
+++ b/api-itineraries-search/src/main/resources/application.yml
@@ -30,6 +30,8 @@ chaos:
 spring:
   profiles:
     active: default
+  jackson:
+    default-property-inclusion: non_null
 
 connector:  
    provider-alpha:

--- a/api-pricing/src/main/resources/application-docker.yml
+++ b/api-pricing/src/main/resources/application-docker.yml
@@ -51,3 +51,5 @@ spring:
         ejb.naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy                
         dialect: org.hibernate.dialect.MySQLDialect
         hbm2ddl.auto: validate
+  jackson:
+    default-property-inclusion: non_null

--- a/api-pricing/src/main/resources/application.yml
+++ b/api-pricing/src/main/resources/application.yml
@@ -51,3 +51,5 @@ spring:
         ejb.naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy                
         dialect: org.hibernate.dialect.MySQLDialect
         hbm2ddl.auto: validate
+  jackson:
+    default-property-inclusion: non_null

--- a/api-provider-alpha/src/main/resources/application-docker.yml
+++ b/api-provider-alpha/src/main/resources/application-docker.yml
@@ -39,7 +39,9 @@ chaos:
 spring:
   profiles:
     active: chaos-monkey
-    
+  jackson:
+    default-property-inclusion: non_null
+
 connector:
    catalog:
       host: api-catalog-varnish:80

--- a/api-provider-alpha/src/main/resources/application.yml
+++ b/api-provider-alpha/src/main/resources/application.yml
@@ -39,7 +39,9 @@ chaos:
 spring:
   profiles:
     active: chaos-monkey
-    
+  jackson:
+    default-property-inclusion: non_null
+
 connector:
    catalog:
       host: localhost:6070

--- a/api-provider-beta/src/main/resources/application-docker.yml
+++ b/api-provider-beta/src/main/resources/application-docker.yml
@@ -39,7 +39,9 @@ chaos:
 spring:
   profiles:
     active: chaos-monkey
-        
+  jackson:
+    default-property-inclusion: non_null
+
 connector:
    catalog:
       host: api-catalog-varnish:80

--- a/api-provider-beta/src/main/resources/application.yml
+++ b/api-provider-beta/src/main/resources/application.yml
@@ -39,6 +39,8 @@ chaos:
 spring:
   profiles:
     active: chaos-monkey
+  jackson:
+    default-property-inclusion: non_null
     
 connector:
    catalog:

--- a/compress/milestone_4/api-itineraries-search.json
+++ b/compress/milestone_4/api-itineraries-search.json
@@ -1,0 +1,1282 @@
+[
+  {
+    "id": "ea1de312-f9ec-45a2-916e-9be7befca7c3",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 0,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 132.58,
+        "base": 778.02,
+        "quantity": 1,
+        "subtotal": 910.6,
+        "total": 910.6,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 87.17,
+        "base": 670.11,
+        "quantity": 1,
+        "subtotal": 757.28,
+        "total": 757.28,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 15.76,
+        "base": 156,
+        "quantity": 1,
+        "subtotal": 171.76,
+        "total": 171.76,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "3c08e796-0932-429c-b01d-eb0785428880",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 6,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 5,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 78.08,
+        "base": 389.22,
+        "quantity": 1,
+        "subtotal": 467.3,
+        "total": 467.3,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 89.04,
+        "base": 801.07,
+        "quantity": 1,
+        "subtotal": 890.11,
+        "total": 890.11,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 152.91,
+        "base": 102.47,
+        "quantity": 1,
+        "subtotal": 255.38,
+        "total": 255.38,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "7fff420b-3cce-4a6e-88d0-27789e29acb7",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 8,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 3,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 200.07,
+        "base": 560.45,
+        "quantity": 1,
+        "subtotal": 760.52,
+        "total": 760.52,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 163.08,
+        "base": 314.91,
+        "quantity": 1,
+        "subtotal": 477.99,
+        "total": 477.99,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 102.84,
+        "base": 674.43,
+        "quantity": 1,
+        "subtotal": 777.27,
+        "total": 777.27,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "KL"
+  },
+  {
+    "id": "c9cc725f-4adf-4120-aa1e-8fd183bfefad",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 6,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 1,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 159.59,
+        "base": 601.75,
+        "quantity": 1,
+        "subtotal": 761.34,
+        "total": 761.34,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 186.51,
+        "base": 469.07,
+        "quantity": 1,
+        "subtotal": 655.58,
+        "total": 655.58,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 25.36,
+        "base": 839.97,
+        "quantity": 1,
+        "subtotal": 865.33,
+        "total": 865.33,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "5801fd13-b244-47d9-8fa9-f1f160d1899b",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 7,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 9,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 96.56,
+        "base": 287.04,
+        "quantity": 1,
+        "subtotal": 383.6,
+        "total": 383.6,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 97.25,
+        "base": 607.61,
+        "quantity": 1,
+        "subtotal": 704.86,
+        "total": 704.86,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 222.64,
+        "base": 86.21,
+        "quantity": 1,
+        "subtotal": 308.85,
+        "total": 308.85,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "c77c3537-c3b4-4c57-98c6-e9c60c2539fd",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 1,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 1,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 65.46,
+        "base": 278.19,
+        "quantity": 1,
+        "subtotal": 343.65,
+        "total": 343.65,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 136.01,
+        "base": 540.1,
+        "quantity": 1,
+        "subtotal": 676.11,
+        "total": 676.11,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 42.33,
+        "base": 307.77,
+        "quantity": 1,
+        "subtotal": 350.1,
+        "total": 350.1,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "FY"
+  },
+  {
+    "id": "344aa96e-c220-4931-99a2-fb8a15c38d31",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 5,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 195.84,
+        "base": 589.82,
+        "quantity": 1,
+        "subtotal": 785.66,
+        "total": 785.66,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 0.99,
+        "base": 57.24,
+        "quantity": 1,
+        "subtotal": 58.23,
+        "total": 58.23,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 64.87,
+        "base": 479.45,
+        "quantity": 1,
+        "subtotal": 544.32,
+        "total": 544.32,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "fef5e2a5-6c01-448c-ac4b-2860ebe7c8f6",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 7,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 219.94,
+        "base": 811.41,
+        "quantity": 1,
+        "subtotal": 1031.35,
+        "total": 1031.35,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 188.84,
+        "base": 977.27,
+        "quantity": 1,
+        "subtotal": 1166.11,
+        "total": 1166.11,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 59.62,
+        "base": 865.8,
+        "quantity": 1,
+        "subtotal": 925.42,
+        "total": 925.42,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "KL"
+  },
+  {
+    "id": "063546a4-1d7c-4181-90d6-dcf4c79fe575",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 9,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 4,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 75.16,
+        "base": 22.97,
+        "quantity": 1,
+        "subtotal": 98.13,
+        "total": 98.13,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 51.99,
+        "base": 674.58,
+        "quantity": 1,
+        "subtotal": 726.57,
+        "total": 726.57,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 195.21,
+        "base": 774.38,
+        "quantity": 1,
+        "subtotal": 969.59,
+        "total": 969.59,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AF"
+  },
+  {
+    "id": "d4523301-2e59-43f4-9ffc-37c9a959b890",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 8,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 195.3,
+        "base": 104.36,
+        "quantity": 1,
+        "subtotal": 299.66,
+        "total": 299.66,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 140.76,
+        "base": 22.26,
+        "quantity": 1,
+        "subtotal": 163.02,
+        "total": 163.02,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 78.81,
+        "base": 419.94,
+        "quantity": 1,
+        "subtotal": 498.75,
+        "total": 498.75,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "04159a04-cd33-45b4-9db0-3f106ca2862e",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 8,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 131.68,
+        "base": 665.3,
+        "quantity": 1,
+        "subtotal": 796.98,
+        "total": 796.98,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 97.94,
+        "base": 869.54,
+        "quantity": 1,
+        "subtotal": 967.48,
+        "total": 967.48,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 159.41,
+        "base": 346.42,
+        "quantity": 1,
+        "subtotal": 505.83,
+        "total": 505.83,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AF"
+  },
+  {
+    "id": "419a8df1-6333-41ef-88e0-7d3110f47da4",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 7,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 201.15,
+        "base": 630.47,
+        "quantity": 1,
+        "subtotal": 831.62,
+        "total": 831.62,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 45.61,
+        "base": 194.94,
+        "quantity": 1,
+        "subtotal": 240.55,
+        "total": 240.55,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 3.01,
+        "base": 99.29,
+        "quantity": 1,
+        "subtotal": 102.3,
+        "total": 102.3,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "DL"
+  },
+  {
+    "id": "949f6097-0d8b-40fc-bfd2-047dd5a2ea71",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 77.78,
+        "base": 683.66,
+        "quantity": 1,
+        "subtotal": 761.44,
+        "total": 761.44,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 48.01,
+        "base": 513.6,
+        "quantity": 1,
+        "subtotal": 561.61,
+        "total": 561.61,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 27.78,
+        "base": 334.47,
+        "quantity": 1,
+        "subtotal": 362.25,
+        "total": 362.25,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "FY"
+  },
+  {
+    "id": "5ab1a4b6-eff6-435d-8587-e089fc65dab0",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 9,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 131.79,
+        "base": 259.04,
+        "quantity": 1,
+        "subtotal": 390.83,
+        "total": 390.83,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 153.24,
+        "base": 879.62,
+        "quantity": 1,
+        "subtotal": 1032.86,
+        "total": 1032.86,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 153.66,
+        "base": 979.7,
+        "quantity": 1,
+        "subtotal": 1133.36,
+        "total": 1133.36,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "84cf789e-39fd-41a8-b171-dd1c9fea01a8",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 1,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 1,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 221.52,
+        "base": 544.01,
+        "quantity": 1,
+        "subtotal": 765.53,
+        "total": 765.53,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 175.01,
+        "base": 960.95,
+        "quantity": 1,
+        "subtotal": 1135.96,
+        "total": 1135.96,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 82.59,
+        "base": 345.21,
+        "quantity": 1,
+        "subtotal": 427.8,
+        "total": 427.8,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "477033ef-1660-4e04-a65e-4ed8a4444cac",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 3,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 108.98,
+        "base": 648.49,
+        "quantity": 1,
+        "subtotal": 757.47,
+        "total": 757.47,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 50.49,
+        "base": 22.34,
+        "quantity": 1,
+        "subtotal": 72.83,
+        "total": 72.83,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 57.34,
+        "base": 855.39,
+        "quantity": 1,
+        "subtotal": 912.73,
+        "total": 912.73,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "DL"
+  },
+  {
+    "id": "9f621c8e-2857-44e6-a81f-4c642ea4b718",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 7,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 112.02,
+        "base": 168.91,
+        "quantity": 1,
+        "subtotal": 280.93,
+        "total": 280.93,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 111,
+        "base": 853.45,
+        "quantity": 1,
+        "subtotal": 964.45,
+        "total": 964.45,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 24.61,
+        "base": 457.44,
+        "quantity": 1,
+        "subtotal": 482.05,
+        "total": 482.05,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "31eba96c-b670-4d02-8378-a782ca1ec20c",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 4,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 3,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 223.45,
+        "base": 25.66,
+        "quantity": 1,
+        "subtotal": 249.11,
+        "total": 249.11,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 194.09,
+        "base": 593.09,
+        "quantity": 1,
+        "subtotal": 787.18,
+        "total": 787.18,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 182.41,
+        "base": 69.38,
+        "quantity": 1,
+        "subtotal": 251.79,
+        "total": 251.79,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "8fe46383-32f0-4887-8543-f0b1ec4f004b",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 7,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 177.17,
+        "base": 241.03,
+        "quantity": 1,
+        "subtotal": 418.2,
+        "total": 418.2,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 176.27,
+        "base": 792.72,
+        "quantity": 1,
+        "subtotal": 968.99,
+        "total": 968.99,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 157.53,
+        "base": 66.87,
+        "quantity": 1,
+        "subtotal": 224.4,
+        "total": 224.4,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "FY"
+  },
+  {
+    "id": "1791f83f-933d-43fa-b7fc-ae23274ea7f2",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 5,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 25.62,
+        "base": 276.34,
+        "quantity": 1,
+        "subtotal": 301.96,
+        "total": 301.96,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 14.03,
+        "base": 787.92,
+        "quantity": 1,
+        "subtotal": 801.95,
+        "total": 801.95,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 187,
+        "base": 788.62,
+        "quantity": 1,
+        "subtotal": 975.62,
+        "total": 975.62,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  }
+]

--- a/compress/milestone_4/api-provider-alpha.json
+++ b/compress/milestone_4/api-provider-alpha.json
@@ -1,0 +1,642 @@
+[
+  {
+    "id": "b2d556e2-800e-46f7-a82f-0d53046eaa76",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 8,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 38.42,
+        "base": 390.7,
+        "quantity": 1,
+        "subtotal": 429.12,
+        "total": 429.12,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 149.52,
+        "base": 271.99,
+        "quantity": 1,
+        "subtotal": 421.51,
+        "total": 421.51,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 164.43,
+        "base": 10.6,
+        "quantity": 1,
+        "subtotal": 175.03,
+        "total": 175.03,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "d61b0023-ec74-452c-b771-42d59f836a10",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 6,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 233.84,
+        "base": 244.76,
+        "quantity": 1,
+        "subtotal": 478.6,
+        "total": 478.6,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 108.34,
+        "base": 931.28,
+        "quantity": 1,
+        "subtotal": 1039.62,
+        "total": 1039.62,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 4.12,
+        "base": 386.12,
+        "quantity": 1,
+        "subtotal": 390.24,
+        "total": 390.24,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "2e178f2b-eb33-4466-a56f-8714e73fca45",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 68.01,
+        "base": 401.54,
+        "quantity": 1,
+        "subtotal": 469.55,
+        "total": 469.55,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 69.46,
+        "base": 150.7,
+        "quantity": 1,
+        "subtotal": 220.16,
+        "total": 220.16,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 147.43,
+        "base": 239.66,
+        "quantity": 1,
+        "subtotal": 387.09,
+        "total": 387.09,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "c99340eb-06b7-432a-8698-4585e745640f",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 24.19,
+        "base": 962.17,
+        "quantity": 1,
+        "subtotal": 986.36,
+        "total": 986.36,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 179.08,
+        "base": 610.6,
+        "quantity": 1,
+        "subtotal": 789.68,
+        "total": 789.68,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 229.59,
+        "base": 593.66,
+        "quantity": 1,
+        "subtotal": 823.25,
+        "total": 823.25,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "a002a787-11e8-4791-b95d-376ba290ad7c",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 19.01,
+        "base": 727.41,
+        "quantity": 1,
+        "subtotal": 746.42,
+        "total": 746.42,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 1.92,
+        "base": 657.21,
+        "quantity": 1,
+        "subtotal": 659.13,
+        "total": 659.13,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 230.44,
+        "base": 243.21,
+        "quantity": 1,
+        "subtotal": 473.65,
+        "total": 473.65,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "2edf0a6a-11b7-4b0c-9ea5-5a17bc9f7c34",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 1,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 230.76,
+        "base": 102.8,
+        "quantity": 1,
+        "subtotal": 333.56,
+        "total": 333.56,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 230.88,
+        "base": 41.3,
+        "quantity": 1,
+        "subtotal": 272.18,
+        "total": 272.18,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 200.67,
+        "base": 952.22,
+        "quantity": 1,
+        "subtotal": 1152.89,
+        "total": 1152.89,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "252a3d3a-ebe9-430f-9b9c-ea587f2a8e1e",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 4,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 3,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 105.13,
+        "base": 539.24,
+        "quantity": 1,
+        "subtotal": 644.37,
+        "total": 644.37,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 168.04,
+        "base": 544.23,
+        "quantity": 1,
+        "subtotal": 712.27,
+        "total": 712.27,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 157.2,
+        "base": 163.01,
+        "quantity": 1,
+        "subtotal": 320.21,
+        "total": 320.21,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "12453e58-e8bc-48d1-831e-7ad2f9ce0e74",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 0,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 4,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 134.8,
+        "base": 392.79,
+        "quantity": 1,
+        "subtotal": 527.59,
+        "total": 527.59,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 31.88,
+        "base": 403.26,
+        "quantity": 1,
+        "subtotal": 435.14,
+        "total": 435.14,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 0.49,
+        "base": 890.81,
+        "quantity": 1,
+        "subtotal": 891.3,
+        "total": 891.3,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  },
+  {
+    "id": "de32afda-69b9-4665-bf83-7b4f451ff7b8",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 3,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 9,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 49.74,
+        "base": 29.94,
+        "quantity": 1,
+        "subtotal": 79.68,
+        "total": 79.68,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 48.69,
+        "base": 487.83,
+        "quantity": 1,
+        "subtotal": 536.52,
+        "total": 536.52,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 99.5,
+        "base": 284.24,
+        "quantity": 1,
+        "subtotal": 383.74,
+        "total": 383.74,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  },
+  {
+    "id": "8eb89692-ed9c-442a-84d9-75e407a4ae51",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 1,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 82.58,
+        "base": 595.52,
+        "quantity": 1,
+        "subtotal": 678.1,
+        "total": 678.1,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 135.32,
+        "base": 829.91,
+        "quantity": 1,
+        "subtotal": 965.23,
+        "total": 965.23,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 126.51,
+        "base": 228.39,
+        "quantity": 1,
+        "subtotal": 354.9,
+        "total": 354.9,
+        "type": "INFANT"
+      }
+    },
+    "provider": "ALPHA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AA"
+  }
+]

--- a/compress/milestone_4/api-provider-beta.json
+++ b/compress/milestone_4/api-provider-beta.json
@@ -1,0 +1,642 @@
+[
+  {
+    "id": "eede702f-0b43-401a-b46c-5254e4b00ac9",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 1,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 8,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 80.7,
+        "base": 482.67,
+        "quantity": 1,
+        "subtotal": 563.37,
+        "total": 563.37,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 60.23,
+        "base": 722.95,
+        "quantity": 1,
+        "subtotal": 783.18,
+        "total": 783.18,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 24.01,
+        "base": 609.3,
+        "quantity": 1,
+        "subtotal": 633.31,
+        "total": 633.31,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "KL"
+  },
+  {
+    "id": "c66a1dbf-9d13-4e74-8d87-5ed19995c3d7",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 3,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 129.49,
+        "base": 807.94,
+        "quantity": 1,
+        "subtotal": 937.43,
+        "total": 937.43,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 40.3,
+        "base": 955.32,
+        "quantity": 1,
+        "subtotal": 995.62,
+        "total": 995.62,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 21.48,
+        "base": 510.82,
+        "quantity": 1,
+        "subtotal": 532.3,
+        "total": 532.3,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "KL"
+  },
+  {
+    "id": "a9789916-104b-47c6-b24c-091042380842",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 0,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 70.61,
+        "base": 548.77,
+        "quantity": 1,
+        "subtotal": 619.38,
+        "total": 619.38,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 13.67,
+        "base": 665.71,
+        "quantity": 1,
+        "subtotal": 679.38,
+        "total": 679.38,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 223.53,
+        "base": 124.33,
+        "quantity": 1,
+        "subtotal": 347.86,
+        "total": 347.86,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "JJ"
+  },
+  {
+    "id": "8aa8fde3-9ec4-46d9-868d-da71ec291613",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 6,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 207.18,
+        "base": 569.59,
+        "quantity": 1,
+        "subtotal": 776.77,
+        "total": 776.77,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 200.28,
+        "base": 260.61,
+        "quantity": 1,
+        "subtotal": 460.89,
+        "total": 460.89,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 158.6,
+        "base": 527.25,
+        "quantity": 1,
+        "subtotal": 685.85,
+        "total": 685.85,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "FY"
+  },
+  {
+    "id": "4aecf665-3bd1-4d2c-bba5-19ac615585c6",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 0,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 0,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 228.8,
+        "base": 798.81,
+        "quantity": 1,
+        "subtotal": 1027.61,
+        "total": 1027.61,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 219.83,
+        "base": 535.57,
+        "quantity": 1,
+        "subtotal": 755.4,
+        "total": 755.4,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 134.59,
+        "base": 789.9,
+        "quantity": 1,
+        "subtotal": 924.49,
+        "total": 924.49,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "JJ"
+  },
+  {
+    "id": "f05e2000-c42f-4987-98d4-4b2a0250363c",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 9,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 82.14,
+        "base": 283.54,
+        "quantity": 1,
+        "subtotal": 365.68,
+        "total": 365.68,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 102.97,
+        "base": 201.26,
+        "quantity": 1,
+        "subtotal": 304.23,
+        "total": 304.23,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 193.85,
+        "base": 115.88,
+        "quantity": 1,
+        "subtotal": 309.73,
+        "total": 309.73,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "FY"
+  },
+  {
+    "id": "09baeefa-afad-4b21-a923-6847577880d1",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 5,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 105.51,
+        "base": 586.28,
+        "quantity": 1,
+        "subtotal": 691.79,
+        "total": 691.79,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 161.38,
+        "base": 454.75,
+        "quantity": 1,
+        "subtotal": 616.13,
+        "total": 616.13,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 8.68,
+        "base": 577.84,
+        "quantity": 1,
+        "subtotal": 586.52,
+        "total": 586.52,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "FY"
+  },
+  {
+    "id": "ee906b38-60f1-4e12-b4b6-23dcaf6ad558",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 6,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 2,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 96.47,
+        "base": 575.27,
+        "quantity": 1,
+        "subtotal": 671.74,
+        "total": 671.74,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 23.35,
+        "base": 739.85,
+        "quantity": 1,
+        "subtotal": 763.2,
+        "total": 763.2,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 76.81,
+        "base": 936.9,
+        "quantity": 1,
+        "subtotal": 1013.71,
+        "total": 1013.71,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "JJ"
+  },
+  {
+    "id": "8de6908f-6003-417a-9ec2-e63642715b47",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 5,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 7,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 222.88,
+        "base": 60.53,
+        "quantity": 1,
+        "subtotal": 283.41,
+        "total": 283.41,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 47.39,
+        "base": 491.65,
+        "quantity": 1,
+        "subtotal": 539.04,
+        "total": 539.04,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 191.18,
+        "base": 821.6,
+        "quantity": 1,
+        "subtotal": 1012.78,
+        "total": 1012.78,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AF"
+  },
+  {
+    "id": "bca0b562-315f-4a69-b215-d0c64c4d3044",
+    "segments": [
+      {
+        "legs": [
+          {
+            "origin": "BUE",
+            "destination": "MIA",
+            "departureDate": "2021-10-29",
+            "departureTime": "06:00",
+            "arrivalDate": "2021-10-29",
+            "arrivalTime": "12:00",
+            "number": 2,
+            "flightDuration": "07:00"
+          }
+        ],
+        "flightDuration": "07:00"
+      },
+      {
+        "legs": [
+          {
+            "origin": "MIA",
+            "destination": "BUE",
+            "departureDate": "2021-11-03",
+            "departureTime": "12:00",
+            "arrivalDate": "2021-11-03",
+            "arrivalTime": "18:00",
+            "number": 4,
+            "flightDuration": "05:00"
+          }
+        ],
+        "flightDuration": "05:00"
+      }
+    ],
+    "priceInfo": {
+      "adults": {
+        "tax": 47.98,
+        "base": 741.49,
+        "quantity": 1,
+        "subtotal": 789.47,
+        "total": 789.47,
+        "type": "ADULT"
+      },
+      "children": {
+        "tax": 45.34,
+        "base": 819,
+        "quantity": 1,
+        "subtotal": 864.34,
+        "total": 864.34,
+        "type": "CHILD"
+      },
+      "infants": {
+        "tax": 163.38,
+        "base": 370.17,
+        "quantity": 1,
+        "subtotal": 533.55,
+        "total": 533.55,
+        "type": "INFANT"
+      }
+    },
+    "provider": "BETA",
+    "flightType": "ROUND_TRIP",
+    "carrier": "AR"
+  }
+]


### PR DESCRIPTION
# Milestone 4 - Remove NULL Values from Your Microservice's JSON Payload

Opted for configuring the Jackson using the `application.yml`, instead of adding to `WebConfiguration`:

```
objectIdMapper.setSerializationInclusion(Include.NON_NULL);
```

Hope that is not a problem. The outcome was the same.

Please check directory `/compress/milestone_4` for the responses after the change. Did not include the responses from `api-catalog`, `api-pricing` and `api-clusters` as the original response did not included any `null`s and the files were exactly the same as without compression.